### PR TITLE
Update GitHub module source to github-0.1.5

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -1,6 +1,6 @@
 module "repositories" {
   for_each = var.repositories
-  source   = "git::https://github.com/mainman94/homelab-terraform-modules.git//modules/github?ref=github-0.1.4"
+  source   = "git::https://github.com/mainman94/homelab-terraform-modules.git//modules/github?ref=github-0.1.5"
 
   name         = each.value.name
   description  = try(each.value.description, null)

--- a/terraform/github/variables.tf
+++ b/terraform/github/variables.tf
@@ -153,11 +153,6 @@ variable "repositories" {
             deletion                = true
             non_fast_forward        = true
             required_linear_history = true
-            pull_request = {
-              dismiss_stale_reviews_on_push     = true
-              required_approving_review_count   = 1
-              required_review_thread_resolution = true
-            }
           }
         }
       }
@@ -175,11 +170,6 @@ variable "repositories" {
             deletion                = true
             non_fast_forward        = true
             required_linear_history = true
-            pull_request = {
-              dismiss_stale_reviews_on_push     = true
-              required_approving_review_count   = 1
-              required_review_thread_resolution = true
-            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- update the shared GitHub module reference to `github-0.1.5`
- consume the release that removes deprecated provider attributes from the module lifecycle ignore list
- stop managing rulesets for `homelab` and `homelab-terraform-modules`

## Validation
- `terraform init -upgrade && terraform plan`
- `terraform validate`

## Notes
- the previous deprecated provider warnings are gone with `github-0.1.5`
- `homelab` and `homelab-terraform-modules` no longer declare Terraform-managed repository rulesets
- Terraform Cloud still shows two normal in-place provider normalization changes from the module update, which must be applied through the VCS workflow
- merge `mainman94/homelab-terraform-modules` PR #1 first, then merge this PR